### PR TITLE
Update to published API and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,33 @@ WeeWX WindGuru - WeeWX extension that publishes data to WindGuru
 Based in large part on the [WindFinder extension](https://github.com/weewx/weewx/wiki/windfinder) written by Matthew Wall.
 
 ## Installation
-1. Register your WindGuru station
-    https://stations.windguru.cz/register.php
+1. Register your [WindGuru station](https://stations.windguru.cz/register.php)
 
 2. Download the extension
-    > wget wget -O weewx-windguru.zip https://github.com/claudobahn/weewx-windguru/archive/master.zip
+
+    ```bash
+    wget -O weewx-windguru.zip https://github.com/claudobahn/weewx-windguru/archive/master.zip
+    ```
 
 3. Run the extension installer:
 
-   > wee_extension --install weewx-windguru.zip
+    ```bash
+    wee_extension --install weewx-windguru.zip
+    ```
 
 4. Update weewx.conf:
+
+    The station_id is also called UID and Weewx ID in windguru, it's a bit confusing.
 
     ```
     [StdRESTful]
         [[WindGuru]]
-            station_id = WindGuru_Station_id
+            station_id = WindGuru_Station_UID
             password = WindGuru_Password
+            post_interval = 60
     ```
+
+
 
 5. Restart WeeWX
 


### PR DESCRIPTION

Windguru published some [API docs](https://stations.windguru.cz/upload_api.php) and I went ahead and switched to those. 

There were actually some bugs that were fixed along the way. The main change is that we now use their `salt+station+pass` MD5 hash as auth. 

Some bug fixes: 
- interval was set to 1 second, but was actually supposed to be the post_interval period which is 5minutes by default. 
- percip_interval was also set to 1, switched the percip parameter to hourRain and pass the interval as 1h

One observation: windguru seems a lot happier with more frequent updates, so I added the config parameter for 60s updates to the readme by default. 
Also went ahead and mentioned the UID/Station ID thing that was suggested in #2, so this Closes #2 if merged. 

